### PR TITLE
Binance Symbol Search and CLI Compliment

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,9 @@ implementations is ideal to facilitate complimentary capabilities where necessar
       - Order Book Ticker: get_book_ticker
       - Get Server Timer: get_server_time
       - Ping: ping
+      - get_recent_trades: /api/v1/trades (incomplete)
+      - get_all_symbols: (get_price wrapper with no symbol spec)
+      - search symbols cli with exchange/binance/cli/get_all_symbols.js
     * WAPI:
       - Asset Detail: get_asset_detail
 * Crypto
@@ -248,8 +251,8 @@ https://github.com/binance-exchange/binance-official-api-docs/blob/master/rest-a
 ```
 cd src/nodejs/
 
-// list the price of neo and total net worth for 10 shares by coinmarketcap valuation
-
+// List the price of neo and total net worth for 10 shares by coinmarketcap valuation.
+// Note: in this version you cannot list all symbols for cmc as you can with binance
 node get_worth -s neo -a 10
 
 
@@ -260,7 +263,26 @@ node get_worth -s neo -a 10
 node get_worth -s neousdt -a 3 -x binance
 
 
+// list the price of all symbols that have "NEO" in the name and multiply their value by 2
+node get_worth.js -a 2 -x binance | grep NEO -A 1
+
+
+// list the price of all symbols on binance times 2 units
+node get_worth.js -a 2 -x binance
+
+
 cd src/nodejs/exchange/binance/cli/
+
+
+// list the price of all symbols on binance times 2 units
+// NOTE: this is not an alias for get worth, this ONLY does binance
+// weight 1
+node get_all_symbols.js -a 2
+
+
+// list the price of all symbols that have "NEO" in the name and multiply their value by 2
+// weight 1
+node get_all_symbols.js -a 2 | grep NEO -A 1
 
 
 // list the best prices on the book at binance

--- a/src/nodejs/exchange/binance/binance-api.js
+++ b/src/nodejs/exchange/binance/binance-api.js
@@ -1,4 +1,5 @@
 // binance.com api module
+// TODO ORganize by MARKET_DATA / USER_DATA etc
 
 // be sure to watch for weight response
 // https://github.com/binance-exchange/binance-official-api-docs/blob/master/rest-api.md
@@ -11,23 +12,36 @@ const hmacSHA256  = require("crypto-js/hmac-sha256");
 
 const dbg         = require('nodejs_util/debug')
 
+
+
+// query binance for all symobls
+// weight 1
+
+exports.get_all_symbols = () => {
+  return this.get_price()
+}
+
 // query binance.com for price info
 // Weight 1
+// return a given coin if coin argument is present, otherwise return all coins
 
-exports.get_price = (coin = 'neousdt', currency = 'usd') => {
+exports.get_price = (coin, currency) => {
   let url = 'https://api.binance.com/api/v3/ticker/price'
+
+  if (coin) url += '?symbol=' + coin.toUpperCase()
 
   console.log('retrieving: ' + url)
   return axios.get(url)
     .then((mapping) => {
-      // const price = mapping.data[0].price_usd
       // dbg.logDeep('map: ', mapping)
-      const res = _.findWhere(mapping.data, {'symbol': coin.toUpperCase()})
-      // dbg.logDeep('map: ', res)
-
-      if (res && res.price) return res.price
-      else console.log('Please provide a valid Binance symbol.')
-      return null
+      // const res = _.findWhere(mapping.data, {'symbol': coin.toUpperCase()})
+      if(coin) {
+        if (mapping && mapping.data && mapping.data.price) return mapping.data
+        else console.log('Please provide a valid Binance symbol.')
+        return null
+      } else {
+        if(mapping && mapping.data) return mapping.data
+      }
     })
     .catch(err => {
       console.log(err.message)
@@ -57,7 +71,8 @@ exports.get_book_ticker = (coin = 'neousdt', currency = 'usd') => {
     })
 }
 
-// get asset_detail (USER_DATA: Requires signed endpoint security)
+// get asset_detail
+// (USER_DATA: Requires signed endpoint security)
 // https://github.com/binance-exchange/binance-official-api-docs/blob/master/rest-api.md
 // SIGNED endpoints require an additional parameter, signature, to be sent in the query string or request body.
 // Endpoints use HMAC SHA256 signatures. The HMAC SHA256 signature is a keyed HMAC SHA256 operation. Use your secretKey as the key and totalParams as the value for the HMAC operation.
@@ -103,6 +118,7 @@ exports.get_book_ticker = (coin = 'neousdt', currency = 'usd') => {
 
 
 // GET /api/v1/trades
+// (MARKET_DATA: requires valid API key)
 // weight 1
 // Parameters:
 //
@@ -110,9 +126,32 @@ exports.get_book_ticker = (coin = 'neousdt', currency = 'usd') => {
 // symbol	STRING	YES
 // limit	INT	     NO	       Default 500; max 1000.
 
- exports.get_trade_history = (symbol, limit) => {
+ exports.get_recent_trades = (api_key, symbol, limit) => {
+   let url = 'https://api.binance.com//wapi/v3/assetDetail.html?' + ts + '&signature=' + tsHash
 
+   var config = {
+     headers: {'X-MBX-APIKEY': api_key}
+   }
 
+   return axios.get(url, config)
+     .then((mapping) => {
+
+       // dbg.logDeep('mapping: ', mapping.data)
+       if(mapping && mapping.data)
+
+       // get a specific symbol if defined
+       if (symbol && symbol.length > 0) {
+         // const res = _.findWhere(mapping.data.asset, {'symbol': symbol.toUpperCase()})
+         const res = mapping.data.assetDetail[symbol.toUpperCase()]
+         return res
+       }
+       // else return the whole list of assets
+       return mapping.data
+     })
+     .catch(err => {
+       console.log(err.message)
+       throw err
+     })
  }
 
 

--- a/src/nodejs/exchange/binance/cli/get_all_symbols.js
+++ b/src/nodejs/exchange/binance/cli/get_all_symbols.js
@@ -1,0 +1,52 @@
+// Get the price of a symbol at a given amount on binance
+
+require('module-alias/register')
+
+
+const program = require('commander')
+const _       = require('underscore')
+
+const dbg     = require('nodejs_util/debug')
+const binance = require('nodejs_exchange/binance/binance-api.js')
+var cfg       = require('nodejs_config/config')
+
+var config    = cfg.load('nodejs_config/neoscan.config.json')
+
+function print(msg) {
+  console.log(msg);
+}
+
+var address, exchange, get_price, symbol
+
+program
+  .version('0.1.0')
+  .usage('-s <symbol> -a <amount> -x [exchange]')
+  .option('-d, --debug', 'Debug')
+  .option('-n, --net [net]', 'Select Neoscan network [net]: i.e., test_net or main_net (will use correct neoscan host and path respectively - defaults to test_net)', 'test_net')
+  .option('-a, --amount <amount>', 'Specify the amount of symbol for which to find value')
+  .option('-s, --symbol [symbol]', 'Specify the symbol to look its value')
+  .parse(process.argv);
+
+if (!program.net) {
+  // print('network: ' + program.net);
+}
+
+if (!program.amount) {
+  program.help()
+}
+
+get_price = binance.get_price
+
+if (program.debug) {
+  print('DEBUGGING');
+}
+
+get_price(program.symbol).then(result => {
+  if(result && result.symbol && result.price) {
+    print(result.symbol +' usd value: ' + result.price + '\n' + 'net worth for amount: ' + result.price * program.amount)
+  } else if(result && result.length) {
+    result.forEach((coin) => {
+      print(coin.symbol + ' usd value: ' + coin.price + '\n' + 'net worth for amount: ' + coin.price * program.amount)
+    })
+  }
+})

--- a/src/nodejs/exchange/binance/cli/get_all_symbols.js
+++ b/src/nodejs/exchange/binance/cli/get_all_symbols.js
@@ -20,7 +20,7 @@ var address, exchange, get_price, symbol
 
 program
   .version('0.1.0')
-  .usage('-s <symbol> -a <amount> -x [exchange]')
+  .usage('-s [symbol] -a <amount>')
   .option('-d, --debug', 'Debug')
   .option('-n, --net [net]', 'Select Neoscan network [net]: i.e., test_net or main_net (will use correct neoscan host and path respectively - defaults to test_net)', 'test_net')
   .option('-a, --amount <amount>', 'Specify the amount of symbol for which to find value')

--- a/src/nodejs/get_worth.js
+++ b/src/nodejs/get_worth.js
@@ -1,4 +1,5 @@
 // Get the price of a symbol at a given amount on either binance or cmc
+// TODO break these out into binance and cmc respectively also
 
 require('module-alias/register')
 
@@ -17,7 +18,7 @@ function print(msg) {
   console.log(msg);
 }
 
-var address, exchange, get_price
+var address, exchange, get_price, symbol
 
 program
   .version('0.1.0')
@@ -25,7 +26,7 @@ program
   .option('-d, --debug', 'Debug')
   .option('-n, --net [net]', 'Select Neoscan network [net]: i.e., test_net or main_net (will use correct neoscan host and path respectively - defaults to test_net)', 'test_net')
   .option('-a, --amount <amount>', 'Specify the amount of symbol for which to find value')
-  .option('-s, --symbol <symbol>', 'Specify the symbol to look its value')
+  .option('-s, --symbol [symbol]', 'Specify the symbol to look its value')
   .option('-x, --exchange [exchange]', 'Specify exchange or api to use to query prices - defaults to coinmarketcap', 'cmc')
   .parse(process.argv);
 
@@ -33,7 +34,7 @@ if (!program.net) {
   // print('network: ' + program.net);
 }
 
-if (!program.symbol || !program.amount) {
+if (!program.amount) {
   program.help()
 }
 
@@ -47,7 +48,25 @@ if (program.debug) {
   print('DEBUGGING');
 }
 
-
-get_price(program.symbol).then(result => {
-  if(result) print('usd value: '+ result + '\n' + 'net worth for amount: ' + result * program.amount)
-})
+switch(exchange) {
+  case "binance":
+    get_price(program.symbol).then(result => {
+      if(result && result.symbol && result.price) {
+        print(result.symbol +' usd value: ' + result.price + '\n' + 'net worth for amount: ' + result.price * program.amount)
+        print('usd value: ' + result.symbol + '\n' + 'net worth fr amount: ' + result.price * program.amount)
+      } else if(result && result.length) {
+        result.forEach((coin) => {
+          print(coin.symbol + ' usd value: ' + coin.price + '\n' + 'net worth for amount: ' + coin.price * program.amount)
+        })
+      }
+    })
+    break;
+  default: // coinmarketcap
+    if (!program.symbol) symbol = 'NEO'
+    else symbol = program.symbol
+    get_price(symbol).then(result => {
+      if(result) {
+        print(symbol + ' usd value: ' + result + '\n' + 'net worth for amount: ' + result * program.amount)
+      }
+    })
+}

--- a/src/nodejs/get_worth.js
+++ b/src/nodejs/get_worth.js
@@ -22,7 +22,7 @@ var address, exchange, get_price, symbol
 
 program
   .version('0.1.0')
-  .usage('-s <symbol> -a <amount> -x [exchange]')
+  .usage('-s [symbol] -a <amount> -x [exchange]')
   .option('-d, --debug', 'Debug')
   .option('-n, --net [net]', 'Select Neoscan network [net]: i.e., test_net or main_net (will use correct neoscan host and path respectively - defaults to test_net)', 'test_net')
   .option('-a, --amount <amount>', 'Specify the amount of symbol for which to find value')

--- a/src/nodejs/neon-js/cli/sendAsset.js
+++ b/src/nodejs/neon-js/cli/sendAsset.js
@@ -20,23 +20,22 @@ function print(msg) {
   console.log(msg);
 }
 
-var address, exchange, get_price
+var address, get_price
 
 program
   .version('0.1.0')
-  .usage('-s <symbol> -a <amount> -x [exchange]')
+  .usage('-s <symbol> -v <value>')
   .option('-d, --debug', 'Debug')
   .option('-n, --net [net]', 'Select Neoscan network [net]: i.e., test_net or main_net (will use correct neoscan host and path respectively - defaults to test_net)', 'test_net')
-  .option('-a, --amount <amount>', 'Specify the amount of symbol for which to find value')
-  .option('-s, --symbol <symbol>', 'Specify the symbol to look its value')
-  .option('-x, --exchange [exchange]', 'Specify exchange or api to use to query prices - defaults to coinmarketcap', 'cmc')
+  .option('-v, --value <value>', 'Specify the amount of symbol to send')
+  .option('-s, --symbol <symbol>', 'Specify the symbol of the currency to send')
   .parse(process.argv);
 
 if (!program.net) {
   // print('network: ' + program.net);
 }
 
-if (!program.symbol || !program.amount) {
+if (!program.symbol || !program.value) {
   program.help()
 }
 

--- a/src/nodejs/shacli.js
+++ b/src/nodejs/shacli.js
@@ -1,4 +1,5 @@
 // neoscan shacli
+// generate a sha256  hash of a message using hmac with a secret or vanilla sha256
 
 require('module-alias/register')
 


### PR DESCRIPTION
    - get_recent_trades: /api/v1/trades (incomplete)
    - get_all_symbols: (get_price wrapper with no symbol spec)
    - search symbols cli with exchange/binance/cli/get_all_symbols.js

// List the price of neo and total net worth for 10 shares by coinmarketcap valuation.
// Note: in this version you cannot list all symbols for cmc as you can with binance
node get_worth -s neo -a 10


// list the price of neousdt and total net worth for 3 shares by binance valuation
// ticker names found at https://api.binance.com/api/v3/ticker/price
// weight 1 for binance

node get_worth -s neousdt -a 3 -x binance


// list the price of all symbols that have "NEO" in the name and multiply their value by 2
node get_worth.js -a 2 -x binance | grep NEO -A 1


// list the price of all symbols on binance times 2 units
node get_worth.js -a 2 -x binance


cd src/nodejs/exchange/binance/cli/


// list the price of all symbols on binance times 2 units
// NOTE: this is not an alias for get worth, this ONLY does binance
// weight 1
node get_all_symbols.js -a 2


// list the price of all symbols that have "NEO" in the name and multiply their value by 2
// weight 1
node get_all_symbols.js -a 2 | grep NEO -A 1