### PR TITLE
Debug Flags, Shell example, CLI Module Updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ With neotools in place, one would have easy lookup of various operations and fun
 
 ## Project Version and Status
 
-Version: 0.36.0
+Version: 0.37.0
 
 Status: Writing alpha code (see section Features below), documenting goals, and defining standards
 
@@ -200,7 +200,7 @@ This will likely be reorganized to have wallet/accounts configured somewhere els
 NOTE: If you have an account configured as default: true in config.json you can omit the address argument and it will use that one.
 
 
-### accountSelected
+### Accounts
 
 ```
 cd src/nodejs/account/CLI
@@ -360,6 +360,39 @@ cd src/nodejs/
 // -r / --readstdin indicates to read stdin as json
 node account/cli/list.js | node neoscan/cli/get_balance.js -r
 
+
+```
+
+### Shell Script Example
+The following shell script will loop a number of cli modules to monitor.
+
+```
+#!/bin/bash
+
+loc="/home/fet/nwd/phetter/neotools/src/nodejs/"
+
+while true;
+  do
+    node ${loc}neoscan/cli/get_balance.js -a insert_address -n mainnet;
+    node ${loc}neoscan/cli/get_balance.js -n mainnet -a insert_address;
+    node ${loc}neoscan/cli/get_balance.js -n mainnet -a insert_address;
+    node ${loc}neoscan/cli/get_last_block_time.js -n mainnet;
+    node ${loc}exchange/binance/cli/get_asset_detail.js -s neo;
+
+    echo -e "\n";
+    node ${loc}get_worth.js -s neo -a 1 -d -x binance;
+    echo -e "";
+    node ${loc}get_worth.js -s gas -a 1;
+    echo -e "\n";
+    node ${loc}get_worth.js -s bitcoin -a 1;
+    echo -e "\n";
+    node ${loc}get_worth.js -s cardano -a 1;
+    echo -e "\n";
+    node ${loc}get_worth.js -a 1 -s bobs-repair;
+    echo -e "\n";
+
+    sleep 500;
+  done
 
 ```
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "neotools",
-  "version": "0.36.0",
+  "version": "0.37.0",
   "description": "Composable command line tools and reference implementations for Neo Smart Economy function primitives",
   "repository": {
     "type": "git",

--- a/src/nodejs/exchange/binance/binance-api.js
+++ b/src/nodejs/exchange/binance/binance-api.js
@@ -14,6 +14,19 @@ const dbg         = require('nodejs_util/debug')
 
 
 
+var defly = false
+
+// Run this to configure API
+// debug = true | turns on verbose activity console printing
+
+exports.debug = (debug) => {
+  if (debug !== undefined) defly = debug
+  else defly = !defly
+  if (defly) console.log('binance api debugging enabled')
+  else console.log('This is your last debugging message! binance api debugging disabled')
+}
+
+
 // query binance for all symobls
 // weight 1
 
@@ -30,7 +43,8 @@ exports.get_price = (coin, currency) => {
 
   if (coin) url += '?symbol=' + coin.toUpperCase()
 
-  console.log('retrieving: ' + url)
+  if (defly) console.log('retrieving: ' + url)
+
   return axios.get(url)
     .then((mapping) => {
       // dbg.logDeep('map: ', mapping)
@@ -44,6 +58,7 @@ exports.get_price = (coin, currency) => {
       }
     })
     .catch(err => {
+      console.log('\nIf you are seeing 400 error, you may want to make sure you are using the right symbol. Try "get_all_symbols -a 1"\n')
       console.log(err.message)
       throw err
     })
@@ -58,7 +73,9 @@ exports.get_worth = (symbol, amount, currency) => {
 
 exports.get_book_ticker = (coin = 'neousdt', currency = 'usd') => {
   let url = 'https://api.binance.com/api/v3/ticker/bookTicker'
-  console.log('retrieving: ' + url)
+
+  if (defly) console.log('retrieving: ' + url)
+
   return axios.get(url)
     .then((mapping) => {
       const res = _.findWhere(mapping.data, {'symbol': coin.toUpperCase()})
@@ -86,7 +103,7 @@ exports.get_book_ticker = (coin = 'neousdt', currency = 'usd') => {
 
   var tsHash = hmacSHA256(ts, api_secret).toString()
 
-  // console.log('retrieving: ' + 'https://api.binance.com//wapi/v3/assetDetail.html?' + ts + '&signature=' + tsHash)
+  if (defly) console.log('retrieving: ' + 'https://api.binance.com//wapi/v3/assetDetail.html?' + ts + '&signature=' + tsHash)
 
   let url = 'https://api.binance.com//wapi/v3/assetDetail.html?' + ts + '&signature=' + tsHash
 
@@ -133,6 +150,8 @@ exports.get_book_ticker = (coin = 'neousdt', currency = 'usd') => {
      headers: {'X-MBX-APIKEY': api_key}
    }
 
+   if (defly) console.log('retrieving: ' + url)
+
    return axios.get(url, config)
      .then((mapping) => {
 
@@ -167,7 +186,9 @@ exports.get_book_ticker = (coin = 'neousdt', currency = 'usd') => {
 
 exports.ping = () => {
   let url = 'https://api.binance.com/api/v1/ping'
-  console.log('retrieving: ' + url)
+
+  if (defly) console.log('retrieving: ' + url)
+
   return axios.get(url)
     .then((mapping) => {
       return mapping.data
@@ -195,7 +216,9 @@ exports.ping = () => {
 // It is left to the caller to convert the date!
 exports.get_server_time = () => {
   let url = 'https://api.binance.com/api/v1/time'
-  console.log('retrieving: ' + url)
+
+  if (defly) console.log('retrieving: ' + url)
+
   return axios.get(url)
     .then((mapping) => {
       return mapping.data

--- a/src/nodejs/exchange/binance/cli/get_all_symbols.js
+++ b/src/nodejs/exchange/binance/cli/get_all_symbols.js
@@ -22,14 +22,9 @@ program
   .version('0.1.0')
   .usage('-s [symbol] -a <amount>')
   .option('-d, --debug', 'Debug')
-  .option('-n, --net [net]', 'Select Neoscan network [net]: i.e., test_net or main_net (will use correct neoscan host and path respectively - defaults to test_net)', 'test_net')
   .option('-a, --amount <amount>', 'Specify the amount of symbol for which to find value')
   .option('-s, --symbol [symbol]', 'Specify the symbol to look its value')
   .parse(process.argv);
-
-if (!program.net) {
-  // print('network: ' + program.net);
-}
 
 if (!program.amount) {
   program.help()
@@ -39,6 +34,7 @@ get_price = binance.get_price
 
 if (program.debug) {
   print('DEBUGGING');
+  binance.debug(true)
 }
 
 get_price(program.symbol).then(result => {

--- a/src/nodejs/exchange/binance/cli/get_asset_detail.js
+++ b/src/nodejs/exchange/binance/cli/get_asset_detail.js
@@ -36,6 +36,7 @@ if (program.symbol) {
 
 if (program.debug) {
   print('DEBUGGING');
+  binance.debug(true)
 }
 
 binance.get_asset_detail(extCfg.exchanges.binance.apiKey, extCfg.exchanges.binance.secret, symbol).then(result => {

--- a/src/nodejs/exchange/binance/cli/get_book_ticker.js
+++ b/src/nodejs/exchange/binance/cli/get_book_ticker.js
@@ -29,6 +29,7 @@ if (!program.symbol) {
 
 if (program.debug) {
   print('DEBUGGING');
+  binance.debug(true)
 }
 
 binance.get_book_ticker(program.symbol).then(result => {

--- a/src/nodejs/exchange/binance/cli/get_server_time.js
+++ b/src/nodejs/exchange/binance/cli/get_server_time.js
@@ -25,6 +25,7 @@ program
 
 if (program.debug) {
   print('DEBUGGING');
+  binance.debug(true)
 }
 
 binance.get_server_time().then(result => {

--- a/src/nodejs/exchange/binance/cli/ping.js
+++ b/src/nodejs/exchange/binance/cli/ping.js
@@ -25,6 +25,7 @@ program
 
 if (program.debug) {
   print('DEBUGGING');
+  binance.debug(true)
 }
 
 binance.ping().then(result => {

--- a/src/nodejs/get_worth.js
+++ b/src/nodejs/get_worth.js
@@ -24,15 +24,11 @@ program
   .version('0.1.0')
   .usage('-s [symbol] -a <amount> -x [exchange]')
   .option('-d, --debug', 'Debug')
-  .option('-n, --net [net]', 'Select Neoscan network [net]: i.e., test_net or main_net (will use correct neoscan host and path respectively - defaults to test_net)', 'test_net')
   .option('-a, --amount <amount>', 'Specify the amount of symbol for which to find value')
   .option('-s, --symbol [symbol]', 'Specify the symbol to look up its value')
   .option('-x, --exchange [exchange]', 'Specify exchange or api to use to query prices - defaults to coinmarketcap', 'cmc')
   .parse(process.argv);
 
-if (!program.net) {
-  // print('network: ' + program.net);
-}
 
 if (!program.amount) {
   program.help()
@@ -46,6 +42,8 @@ if (program.exchange) {
 
 if (program.debug) {
   print('DEBUGGING');
+  if(exchange === 'binance') binance.debug(true)
+  else cmc.debug(true)
 }
 
 switch(exchange) {

--- a/src/nodejs/market/coinmarketcap/get_price.js
+++ b/src/nodejs/market/coinmarketcap/get_price.js
@@ -6,8 +6,21 @@ const axios = require('axios')
 const dbg = require('nodejs_util/debug')
 
 
+var defly = false
+
+// Run this to configure API
+// debug = true | turns on verbose activity console printing
+
+exports.debug = (debug) => {
+  if (debug !== undefined) defly = debug
+  else defly = !defly
+  if (defly) console.log('coinmarketcap api debugging enabled')
+  else console.log('This is your last debugging message! coinmarketcap api debugging disabled')
+}
+
+
 exports.get_price = (coin = 'NEO', currency = 'usd') => {
-  console.log('retrieving: ' + `https://api.coinmarketcap.com/v1/ticker/${coin.toLowerCase()}/`)
+  if (defly) console.log('retrieving: ' + `https://api.coinmarketcap.com/v1/ticker/${coin.toLowerCase()}/`)
   return axios.get('https://api.coinmarketcap.com/v1/ticker/'+ coin.toLowerCase())
     .then((mapping) => {
       const price = mapping.data[0].price_usd

--- a/src/nodejs/neoscan/cli/get_address_abstracts.js
+++ b/src/nodejs/neoscan/cli/get_address_abstracts.js
@@ -53,6 +53,7 @@ if (program.page)  {
 
 if (program.debug) {
   print('DEBUGGING');
+  neoscan.debug(true)
 }
 
 

--- a/src/nodejs/neoscan/cli/get_all_nodes.js
+++ b/src/nodejs/neoscan/cli/get_all_nodes.js
@@ -20,6 +20,7 @@ program
 
 if (program.debug) {
   print('DEBUGGING');
+  neoscan.debug(true)
 }
 
 neoscan.set_net(program.net)

--- a/src/nodejs/neoscan/cli/get_balance.js
+++ b/src/nodejs/neoscan/cli/get_balance.js
@@ -35,6 +35,7 @@ program
 
 if (program.debug) {
   print('DEBUGGING')
+  neoscan.debug(true)
 }
 
 // read address from json on stdin using pattern provided at cli arg, if present

--- a/src/nodejs/neoscan/cli/get_block.js
+++ b/src/nodejs/neoscan/cli/get_block.js
@@ -30,6 +30,7 @@ if (!program.hash) {
 
 if (program.debug) {
   print('DEBUGGING');
+  neoscan.debug(true)
 }
 
 neoscan.set_net(program.net)

--- a/src/nodejs/neoscan/cli/get_claimable.js
+++ b/src/nodejs/neoscan/cli/get_claimable.js
@@ -36,6 +36,7 @@ program
 
 if (program.debug) {
   print('DEBUGGING');
+  neoscan.debug(true)
 }
 
 // read address from json on stdin using pattern provided at cli arg, if present

--- a/src/nodejs/neoscan/cli/get_claimed.js
+++ b/src/nodejs/neoscan/cli/get_claimed.js
@@ -36,6 +36,7 @@ program
 
   if (program.debug) {
     print('DEBUGGING');
+    neoscan.debug(true)
   }
 
   // read address from json on stdin using pattern provided at cli arg, if present

--- a/src/nodejs/neoscan/cli/get_height.js
+++ b/src/nodejs/neoscan/cli/get_height.js
@@ -24,6 +24,7 @@ if (!program.net) {
 
 if (program.debug) {
   print('DEBUGGING');
+  neoscan.debug(true)
 }
 
 neoscan.set_net(program.net)

--- a/src/nodejs/neoscan/cli/get_last_block.js
+++ b/src/nodejs/neoscan/cli/get_last_block.js
@@ -25,6 +25,7 @@ if (!program.net) {
 
 if (program.debug) {
   print('DEBUGGING');
+  neoscan.debug(true)
 }
 
 neoscan.set_net(program.net)

--- a/src/nodejs/neoscan/cli/get_last_block_time.js
+++ b/src/nodejs/neoscan/cli/get_last_block_time.js
@@ -27,6 +27,7 @@ if (!program.net) {
 
 if (program.debug) {
   print('DEBUGGING');
+  neoscan.debug(true)
 }
 
 neoscan.set_net(program.net)

--- a/src/nodejs/neoscan/cli/get_last_transactions_by_address.js
+++ b/src/nodejs/neoscan/cli/get_last_transactions_by_address.js
@@ -47,6 +47,7 @@ if (program.page)  {
 
 if (program.debug) {
   print('DEBUGGING');
+  neoscan.debug(true)
 }
 
 

--- a/src/nodejs/neoscan/cli/get_transaction.js
+++ b/src/nodejs/neoscan/cli/get_transaction.js
@@ -29,6 +29,7 @@ if (!program.hash) {
 
 if (program.debug) {
   print('DEBUGGING');
+  neoscan.debug(true)
 }
 
 neoscan.set_net(program.net)

--- a/src/nodejs/neoscan/cli/get_unclaimed.js
+++ b/src/nodejs/neoscan/cli/get_unclaimed.js
@@ -35,6 +35,7 @@ program
 
   if (program.debug) {
     print('DEBUGGING');
+    neoscan.debug(true)
   }
 
   // read address from json on stdin using pattern provided at cli arg, if present

--- a/src/nodejs/neoscan/neoscan.js
+++ b/src/nodejs/neoscan/neoscan.js
@@ -52,12 +52,26 @@ exports.syncState = state => {
 curState = state
 }
 
+
+var defly = false
+
+// Run this to configure API
+// debug = true | turns on verbose activity console printing
+
+exports.debug = (debug) => {
+  if (debug !== undefined) defly = debug
+  else defly = !defly
+  if (defly) console.log('neoscan api debugging enabled')
+  else console.log('This is your last debugging message! neoscan api debugging disabled')
+}
+
+
 // Check if our url is properly formed. If url can't construct it in try, it isn't.
 const validateUrl = url => {
   return new Promise((resolve, reject) => {
     try {
       const u = new URL(url)
-      console.log('host: ' + u)
+      if (defly) console.log('host: ' + u)
       resolve(url)
     } catch (error) {
       console.log('neoscan: validateUrl: ' + error.message)
@@ -125,7 +139,7 @@ exports.switchNetwork = networkId => {
         net = curState.config.neoscan.active = curState.config.networks[networkId]
       } else {
         // if (curState.config.neoscan[networkId].apiType !== 'neoscan') return undefined
-        console.log('networkId: ' + networkId)
+        if (defly) console.log('networkId: ' + networkId)
         let u = curState.config.neoscan[networkId].url
         let custom = {}
         custom.name = curState.config.neoscan[networkId].name
@@ -170,7 +184,7 @@ exports.getRootUrl = () => {
 exports.get_address_abstracts = (address, page) => {
   return new Promise((resolve, reject) => {
     this.getRootUrl(address).then(url => {
-      console.log('url: ' + url + '/v1/get_address_abstracts/' + address + '/' + page)
+      if (defly) console.log('url: ' + url + '/v1/get_address_abstracts/' + address + '/' + page)
       return axios
         .get(url + '/v1/get_address_abstracts/' + address + '/' + page)
         .then(response => {
@@ -205,11 +219,11 @@ exports.get_last_transactions_by_address = (address, page) => {
   if (page) pageArg = page
   return new Promise((resolve, reject) => {
     this.get_last_transactions_by_address_url(address, pageArg).then(url => {
-      console.log(url)
+      if (defly) console.log(url)
       return axios
         .get(url)
         .then(response => {
-          console.log(`Retrieved History for ${address} from neoscan ${url}`)
+          if (defly) console.log(`Retrieved History for ${address} from neoscan ${url}`)
           response.data.address = address
           resolve({ data: response.data, address: address })
         })
@@ -237,7 +251,7 @@ exports.get_transaction_url = txid => {
 exports.get_transaction = txid => {
   return new Promise((resolve, reject) => {
     this.get_transaction_url(txid).then(url => {
-      console.log(`Retrieving ${txid} History from neoscan ${url}`)
+      if (defly) console.log(`Retrieving ${txid} History from neoscan ${url}`)
       return axios
         .get(url)
         .then(response => {
@@ -255,7 +269,7 @@ exports.get_transaction = txid => {
 // I.e., 'https://neoscan.io/api/main_net/v1/get_transaction/'
 
 exports.get_balance_url = address => {
-  console.log(curState.config.neoscan.active.balanceUrl, address)
+  if (defly) console.log(curState.config.neoscan.active.balanceUrl, address)
   if (address) {
     return validateUrl(curState.config.neoscan.active.balanceUrl + '/' + address + '/')
   } else return validateUrl(curState.config.neoscan.active.balanceUrl)
@@ -264,7 +278,7 @@ exports.get_balance_url = address => {
 exports.get_balance = address => {
   return new Promise((resolve, reject) => {
     this.get_balance_url(address).then(url => {
-      console.log(`Retrieving balance for ${address} from neoscan ${url}`)
+      if (defly) console.log(`Retrieving balance for ${address} from neoscan ${url}`)
       return axios
         .get(url)
         .then(response => {
@@ -319,7 +333,7 @@ exports.get_unclaimed_url = address => {
 exports.get_unclaimed = address => {
   return new Promise((resolve, reject) => {
     this.get_unclaimed_url(address).then(url => {
-      console.log(`querying unclaimed gas`)
+      if (defly) console.log(`querying unclaimed gas`)
       return axios
         .get(url)
         .then(response => {
@@ -342,7 +356,7 @@ exports.get_claimable_url = address => {
 exports.get_claimable = address => {
   return new Promise((resolve, reject) => {
     this.get_claimable_url(address).then(url => {
-      console.log(`querying claimable transactions`)
+      if (defly) console.log(`querying claimable transactions`)
       return axios
         .get(url)
         .then(response => {
@@ -366,7 +380,7 @@ exports.get_claimed_url = address => {
 exports.get_claimed = address => {
   return new Promise((resolve, reject) => {
     this.get_claimed_url(address).then(url => {
-      console.log(`querying claimed transactions`)
+      if (defly) console.log(`querying claimed transactions`)
       return axios
         .get(url)
         .then(response => {
@@ -389,7 +403,7 @@ exports.get_height_url = () => {
 exports.get_height = () => {
   return new Promise((resolve, reject) => {
     this.get_height_url().then(url => {
-      console.log(`Retrieving block height`)
+      if (defly) console.log(`Retrieving block height`)
       return axios
         .get(url)
         .then(response => {
@@ -413,7 +427,7 @@ exports.get_block_url = hash => {
 exports.get_block = (hash) => {
   return new Promise((resolve, reject) => {
     this.get_block_url(hash).then(url => {
-      console.log(`Retrieving block by hash or index`)
+      if (defly) console.log(`Retrieving block by hash or index`)
       return axios
         .get(url)
         .then(response => {
@@ -436,7 +450,7 @@ return validateUrl(curState.config.neoscan.active.rootUrl + '/v1/get_all_nodes')
 exports.get_all_nodes = () => {
   return new Promise((resolve, reject) => {
     this.get_all_nodes_url().then(url => {
-      console.log(`Retrieving node list`)
+      if (defly) console.log(`Retrieving node list`)
       return axios
         .get(url)
         .then(response => {

--- a/src/nodejs/neostatus/cli/network_vitals.js
+++ b/src/nodejs/neostatus/cli/network_vitals.js
@@ -28,6 +28,7 @@ program
 
 if (program.debug) {
   print('DEBUGGING');
+  neoscan.debug(true)
 }
 
 print(program.net)

--- a/src/nodejs/neostatus/cli/node_vitals.js
+++ b/src/nodejs/neostatus/cli/node_vitals.js
@@ -33,6 +33,7 @@ if (!program.node) {
 
 if (program.debug) {
   print('DEBUGGING');
+  neoscan.debug(true)
 }
 
 const client = neon.default.create.rpcClient(program.node)


### PR DESCRIPTION
- Cleaned up output formatting and added debug (defly) flag usage for binance, cmc, and neoscan API modules
  - CLI modules now utilize debug flags
- Added bash shell script example of how to use CLI modules to reach mission goals